### PR TITLE
Add notap to submenu

### DIFF
--- a/core-submenu.html
+++ b/core-submenu.html
@@ -61,7 +61,7 @@ The above will style `Topic1` and `Topic2` to have font color red.
 <link rel="import" href="../core-menu/core-menu.html">
 <link rel="import" href="../core-collapse/core-collapse.html">
 
-<polymer-element name="core-submenu" attributes="selected selectedItem selectedAttribute label icon src valueattr">
+<polymer-element name="core-submenu" attributes="selected selectedItem selectedAttribute label icon src valueattr notap">
 <template>
 
   <link rel="stylesheet" href="core-submenu.css">
@@ -86,6 +86,16 @@ The above will style `Topic1` and `Topic2` to have font color red.
     },
 
     opened: false,
+    
+    /**
+    * Set this to true to disallow changing the selection via the
+    * `activateEvent`.
+    *
+    * @attribute notap
+    * @type boolean
+    * @default false
+    */
+    notap: false,
 
     get items() {
       return this.$.submenu.items;
@@ -114,7 +124,7 @@ The above will style `Topic1` and `Topic2` to have font color red.
     },
 
     activate: function() {
-      if (this.hasItems() && this.active) {
+      if (!this.notap && this.hasItems() && this.active) {
         this.toggle();
         this.unselectAllItems();
       }


### PR DESCRIPTION
When combining <a/> based routing with the <core-submenu/> component, notap is available to the parent <core-menu/> component but not for the <core-submenu/> causing a race condition between the active() and activeChanged() functionalities.

This adds a notap attribute to the <core-submenu/> component to prevent this issue.  

When implementing this approach the use of an ID in the parent <core-menu/> component allows for the chaining of this attribute like so: <core-submenu notap="{{$.parentID.notap}}"/>.